### PR TITLE
ZULU-1487 Ignis > Revamp  > Remove all non-profitable messaging

### DIFF
--- a/en/index.json
+++ b/en/index.json
@@ -241,7 +241,6 @@
     "add_exclusion": "ADD EXCLUSIONS",
     "how_to_add_manually": "How to add manually?",
     "add_exclusions_manually": "Add exclusions manually",
-    "exclusion_confirm": "I HAVE ADDED THE EXCLUSIONS",
     "add_exclusions_manually_help": "Add exclusions manually in case the button above didn't work",
     "exclusion_confirm": "I have added the exclusions"
   },

--- a/en/index.json
+++ b/en/index.json
@@ -63,7 +63,7 @@
     "connection_fail": "Connection error",
     "no_mining_device": "Have no mining device. Must select at least one mining device (GPU or CPU)",
     "no_mining_crypto_for_device": "You must select at least one crypto algorithm in order to mine.",
-    "no_profitable_algorithms": "All mining algorithms are not profitable. You can continue mine by enabling \"Mine even projected profit lost\" options in Settings",
+    "no_profitable_algorithms": "Sorry your hardware is not currently supported. We hope to support it in the future",
     "error_while_calling_miner_function": "Error when calling miner function"
   },
   "home": {

--- a/es/index.json
+++ b/es/index.json
@@ -61,7 +61,7 @@
     "connection_fail": "Error de conexión",
     "no_mining_device": "Sin dispositivo de minado. Selecciona al menos un dispositivo de minado (GPU o CPU)",
     "no_mining_crypto_for_device": "Selecciona al menos un algoritmo de crypto minado",
-    "no_profitable_algorithms": "Ninguno de los algoritmos son rentables. Puedes continuar el proceso de minado activando la opción \"¿Minar monedas incluso cuando las ganancias estimadas se proyectan como pérdidas?\"",
+    "no_profitable_algorithms": "Lo sentimos, su hardware no es compatible actualmente. Esperamos apoyarlo en el futuro.",
     "error_while_calling_miner_function": "Error al llamar a la función de minado. ¿Estás seguro de llevar equipado el pico?"
   },
   "home": {


### PR DESCRIPTION
## Ticket references
- [ZULU-1487](https://freedom.myjetbrains.com/youtrack/issue/ZULU-1487) Ignis > Revamp  > Remove all non-profitable messaging

## Summary of changes
- Update all non-profitable message into hardware not supported

<img width="881" alt="image" src="https://user-images.githubusercontent.com/20008011/162116036-89d712ce-67c1-447e-9e17-1c02d4fb437d.png">

## Checklist
<!--
     Mark the things that have been followed.
-->
- [ ] bugfix
- [ ] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing

Note: Run crypto miner client in Linux box to simulate non profitable algo error. Alternatively, test installer can be installed to a windows box with no supported hardware to trigger the error. Test installer will be provided in the slack test request.

Setup
1. Checkout the master branch of the crypto miner client: https://gitlab.com/mcnfreedom/vn-team/crypto/crypto.miner.client
2. Copy the language folders, en and es, to `build/langs` folder of the crypto miner client
3. Apply the diff provided in the request for testing to use the crypto api staging

Test steps:
1. On the terminal, run the client by executing the following command: `npm run dev`
2. Perform the following steps if required:
    * Accept EULA
    * Add Windows Defender Exclusion and restart Ignis
3. Click on the Signin button to login
5. Select a creator to support
6. Click on the `Start` button to start mining
7. An error message should be displayed with the text `Error when calling miner function` and a warning message should pop up at the bottom with a message `Sorry your hardware is not currently supported. We hope to support it in the future`


